### PR TITLE
Fix config not loading when calling main function

### DIFF
--- a/conf.d/ssh-config.d.fish
+++ b/conf.d/ssh-config.d.fish
@@ -1,4 +1,4 @@
-function init -a path --on-event init_ssh-config.d
+function init -a path --on-event ssh-config.d
   config ssh-config.d --set ssh_config ~/.ssh/config
   config ssh-config.d --set ssh_config_dir ~/.ssh/config.d/
   config ssh-config.d --set warn \
@@ -10,4 +10,3 @@ function init -a path --on-event init_ssh-config.d
 
 "
 end
-


### PR DESCRIPTION
This fixes empty configs when using the plugin 

```
Usage:
  cpbak SOURCE...
fish: Invalid redirection target:
    config ssh-config.d --get warn >$ssh_config
                                   ^
in function 'generate_ssh_config'
	called on line 37 of file ~/.local/share/omf/pkg/ssh-config.d/functions/ssh-config.d.fish
in function 'ssh-config.d'
fish: Invalid redirection target:
    cat $ssh_config_dir/**.config >>$ssh_config
                                  ^
in function 'generate_ssh_config'
	called on line 37 of file ~/.local/share/omf/pkg/ssh-config.d/functions/ssh-config.d.fish
in function 'ssh-config.d'
```